### PR TITLE
Fix a problem with / (forward slash) in the to-be-transliterated name

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,41 +48,41 @@ open an issue here.
 
 ### Japan
 ```
-curl --data "142/43/東京" http://localhost:8080
+transcription-cli/transcribe.py "XY//142/43/東京"
 Toukyou
-curl --data "jp/東京" http://localhost:8080
+transcription-cli/transcribe.py "CC//jp/東京"
 Toukyou
 ```
 
 ### China
 ```
-curl --data "130/43/東京" http://localhost:8080
+transcription-cli/transcribe.py "XY//130/43/東京"
 dōng jīng
-curl --data "cn/東京" http://localhost:8080
+transcription-cli/transcribe.py "CC//cn/東京"
 dōng jīng
 ```
 
 ### Thailand
 ```
-curl --data "101/16/ห้องสมุดประชาชน" http://localhost:8080
+transcription-cli/transcribe.py "XY//101/16/ห้องสมุดประชาชน"
 hongsamut prachachon
-curl --data "th/ห้องสมุดประชาชน" http://localhost:8080
+transcription-cli/transcribe.py "CC//th/ห้องสมุดประชาชน"
 hongsamut prachachon
 ```
 
 ### Macau
 ```
-curl --data "113.6/22.1/香港" http://localhost:8080
+transcription-cli/transcribe.py "XY//113.6/22.1/香港"
 hōeng góng
-curl --data "mo/香港" http://localhost:8080
+transcription-cli/transcribe.py "CC//mo/香港"
 hōeng góng
 ```
 
 ### Hongkong
 ```
-curl --data "113.9/22.25/香港" http://localhost:8080
+transcription-cli/transcribe.py "XY//113.9/22.25/香港"
 hōeng góng
-curl --data "hk/香港" http://localhost:8080
+transcription-cli/transcribe.py "CC//hk/香港"
 hōeng góng
 ```
 

--- a/cc_transcript_via_daemon.sql
+++ b/cc_transcript_via_daemon.sql
@@ -26,7 +26,7 @@ CREATE or REPLACE FUNCTION osml10n_cc_translit(name text, country text DEFAULT '
   try:
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.connect((host, port))
-    data = ('X/' + country + '/' + name).encode('utf-8');
+    data = ('CC/X/' + country + '/' + name).encode('utf-8');
 
     length = len(data)
     sock.sendall(struct.pack('I', length) + data)

--- a/lua_osml10/osml10n/geo_transcript.lua
+++ b/lua_osml10/osml10n/geo_transcript.lua
@@ -17,7 +17,7 @@ function osml10n.geo_transcript(id,name,bbox)
   local lon,lat,reqbody
   local bx = {}
   if (bbox == nil) then
-    reqbody = id .. "/" .. "/" .. name
+    reqbody = "CC/" .. id .. "/" .. "/" .. name
   else
     if (type(bbox) == "function") then
       bx[1], bx[2], bx[3], bx[4] = bbox()
@@ -27,7 +27,7 @@ function osml10n.geo_transcript(id,name,bbox)
     end
       lon = (bx[1]+bx[3])/2.0
       lat = (bx[2]+bx[4])/2.0
-    reqbody = id .. "/" .. lon .. "/" .. lat .. "/" .. name
+    reqbody = "XY/" .. id .. "/" .. lon .. "/" .. lat .. "/" .. name
   end
 
   sock:send(string.pack('s4', reqbody))

--- a/lua_osml10/tests/runtests.lua
+++ b/lua_osml10/tests/runtests.lua
@@ -131,7 +131,7 @@ for _, lang in pairs({"de", "en", "fr"}) do
   print("")
 end
 
--- geo_transcript function via extrnal daemon
+-- geo_transcript function via external daemon
 
 -- Japan
 checkoutput(osml10n.geo_transcript,"geo_transcript","Toukyou",'42',"東京",{ 138.79, 36.08, 139.51, 36.77 })
@@ -159,6 +159,9 @@ checkoutput(osml10n.geo_transcript,"geo_transcript","Moskvá",'42',"Москва
 -- international waters
 checkoutput(osml10n.geo_transcript,"geo_transcript","Moskvá",'42',"Москва́",{-30, 49, -29, 50})
 
+-- check with / (slash character) in the name
+checkoutput(osml10n.geo_transcript,"geo_transcript","some/name",'42',"some/name",{114.15, 22.28, 114.2, 22.33})
+checkoutput(osml10n.geo_transcript,"geo_transcript","some/name",'42',"some/name",nil)
 
 print("")
 

--- a/transcription-cli/transcribe.py
+++ b/transcription-cli/transcribe.py
@@ -2,7 +2,7 @@
 #
 #  Usage: transcribe.py REQUEST
 #
-#  REQUEST must be in format ID/CC/WORDS or ID/LON/LAT/WORDS.
+#  REQUEST must be in format "CC/id/cc/words" or "XY/id/lon/lat/words".
 #
 
 import socket
@@ -10,14 +10,14 @@ import struct
 import sys
 
 def die_usage():
-    sys.stdout.write("uasge: %s ID/CC/WORDS|ID/LON/LAT/WORDS\n" % sys.argv[0])
+    sys.stdout.write("usage: %s CC/id/cc/words|XY/id/lon/lat/words\n" % sys.argv[0])
     sys.exit(1)
 
 if (len(sys.argv) != 2):
     die_usage()
 
-arglen =len(sys.argv[1].split('/'))
-if (arglen < 2) or (arglen > 3):
+arglen = len(sys.argv[1].split('/'))
+if (arglen < 4) or (arglen > 5):
     die_usage()
 
 sock = socket.create_connection(('localhost', 8033))


### PR DESCRIPTION
This changes the protocol of the daemon adding a "command" in front that can either be "CC" or "XY" depending on whether this should do the lookup by country code or by lon/lat.