### PR TITLE
Switch to api.openstreetmap.org API host

### DIFF
--- a/scripts/get_osm_boundaries.sh
+++ b/scripts/get_osm_boundaries.sh
@@ -10,7 +10,7 @@ get_osm_boundary_by_id() {
     local name="$1"
     local id="$2"
 
-    wget -O "$name.osm" "https://www.openstreetmap.org/api/0.6/relation/$id/full"
+    wget -O "$name.osm" "https://api.openstreetmap.org/api/0.6/relation/$id/full"
 
     osmium getid --remove-tags --add-referenced "$name.osm" "r$id" --output-format=opl \
         | sed -e "s/ T[^ ]\+ / Ttype=multipolygon,cc=$name /" >"$name.opl"


### PR DESCRIPTION
Use `api.openstreetmap.org/api/` -and HTTPS- instead of `www.openstreetmap.org/api/*`.

(Is: https://github.com/openstreetmap/operations/issues/951)

cc: @giggls 