### PR TITLE
Pin scipy to < 1.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(
         "shapely",
         "sdnotify",
         "requests",
-        "pandas"
+        "pandas",
+        "scipy<1.13",  # see https://github.com/piskvorky/gensim/issues/3525 (gensim is a transitive dep of tltk)
     ],
     scripts = [ "transcription-daemon/geo-transcript-srv.py", "transcription-cli/transcribe.py" ],
     packages = [ "osml10n" ],


### PR DESCRIPTION
tltk depends on gensim, which currently requires scipy < 1.13 due to some moved functions.

See: https://stackoverflow.com/a/78544073/51685