### PR TITLE
Update openstreetmap-carto-hstore-only-l10n.lua - Switching from `add_row()` to `insert()` for osm2pgsql

### DIFF
--- a/openstreetmap-carto-hstore-only-l10n.lua
+++ b/openstreetmap-carto-hstore-only-l10n.lua
@@ -462,7 +462,7 @@ function add_line(tags, name_l10n, object)
     local mgeom = object:as_linestring():transform(3857):segmentize(100000)
     for sgeom in mgeom:geometries() do
         cols.way = sgeom
-        tables.line:insert({ cols })
+        tables.line:insert(cols)
     end
 end
 
@@ -475,7 +475,7 @@ function add_multiline(tags, name_l10n, object)
     local mgeom =  object:as_multilinestring():line_merge():transform(3857):segmentize(100000)
     for sgeom in mgeom:geometries() do
         cols.way = sgeom
-        tables.line:insert({ cols })
+        tables.line:insert(cols)
     end
 end
 
@@ -488,7 +488,7 @@ function add_roads(tags, name_l10n, object)
     local mgeom = object:as_linestring():transform(3857):segmentize(100000)
     for sgeom in mgeom:geometries() do
         cols.way = sgeom
-        tables.roads:insert({ cols })
+        tables.roads:insert(cols)
     end
 end
 
@@ -501,7 +501,7 @@ function add_multiroads(tags, name_l10n, object)
     local mgeom =  object:as_multilinestring():line_merge():transform(3857):segmentize(100000)
     for sgeom in mgeom:geometries() do
         cols.way = sgeom
-        tables.roads:insert({ cols })
+        tables.roads:insert(cols)
     end
 end
 

--- a/openstreetmap-carto-hstore-only-l10n.lua
+++ b/openstreetmap-carto-hstore-only-l10n.lua
@@ -439,6 +439,15 @@ function remove_name_tags(tags)
     return next(tags) == nil
 end
 
+local function create_cols(tags)
+    local cols = {}
+    cols.tags = tags
+    cols['layer'] = layer(tags['layer'])
+    cols['z_order'] = z_order(tags)
+    cols.name_l10n = name_l10n
+    return cols
+end
+
 --- Splits a tag into tags and hstore tags
 -- @return columns, hstore tags
 function split_tags(tags, tag_map)
@@ -454,11 +463,7 @@ function split_tags(tags, tag_map)
 end
 
 function add_line(tags, name_l10n, mgeom)
-    local cols = {}
-    cols.tags = tags
-    cols['layer'] = layer(tags['layer'])
-    cols['z_order'] = z_order(tags)
-    cols.name_l10n = name_l10n
+    local cols = create_cols(tags)
     for sgeom in mgeom:geometries() do
         cols.way = sgeom
         tables.line:insert(cols)
@@ -466,11 +471,7 @@ function add_line(tags, name_l10n, mgeom)
 end
 
 function add_roads(tags, name_l10n, mgeom)
-    local cols = {}
-    cols.tags = tags
-    cols['layer'] = layer(tags['layer'])
-    cols['z_order'] = z_order(tags)
-    cols.name_l10n = name_l10n
+    local cols = create_cols(tags)
     for sgeom in mgeom:geometries() do
         cols.way = sgeom
         tables.roads:insert(cols)
@@ -478,11 +479,7 @@ function add_roads(tags, name_l10n, mgeom)
 end
 
 function add_polygon(tags, name_l10n, poly)
-    local cols = {}
-    cols.tags = tags
-    cols['layer'] = layer(tags['layer'])
-    cols['z_order'] = z_order(tags)
-    cols.name_l10n = name_l10n
+    local cols = create_cols(tags)
     cols.way = poly
     cols.area = poly:area()
     tables.polygon:insert(cols)


### PR DESCRIPTION
### Background:
I came across the open question in Issue [#4977](https://github.com/gravitystorm/openstreetmap-carto/issues/4977) regarding the potential impact on the German style of OpenStreetMap. To investigate further, I set up a test environment and tested the installation of the openstreetmap.de tile server using the latest version of `osm2pgsql`.

```bash
$ osm2pgsql --version
osm2pgsql version 1.11.0 (1.11.0-136-gf8c78ae3)
Build: RelWithDebInfo
Compiled using the following library versions:
Libosmium 2.20.0
Proj 9.1.1
Lua 5.3.6
```

During the data import process using the following command:

```bash
sudo -u _tirex osm2pgsql -c -d osm --slim -C 0 -O flex \
  --number-processes 1 -S /srv/tile/sources/osml10n/openstreetmap-carto-hstore-only-l10n.lua \
  /srv/tile/planet.osm.pbf
```

I encountered the following error:

```
ERROR: Error loading lua config: ...sources/osml10n/openstreetmap-carto-hstore-only-l10n.lua:81: Error in 'define_table': Unknown column type 'area'. (https://github.com/giggls/osml10n/blob/master/openstreetmap-carto-hstore-only-l10n.lua#L81)
```

### Solution:
Sarah pointed me to this [tutorial](https://osm2pgsql.org/doc/tutorials/switching-from-add-row-to-insert/), which I have now integrated into the Lua script.

### Notes:
This version is likely not perfect; there is redundant code, specifically in the functions `add_multiroads` and `add_roads`  (`add_polygons` and `add_polygons`), which could potentially be combined into a single function by checking the type. However, the current implementation works because the "multi"-function is always called from process_relation, ensuring that the types align correctly and my knowledge of the types is limited, and since this solution works, I'm submitting it for your review as is.


