### PR TITLE
Add missing abbreviations

### DIFF
--- a/lua_osml10/osml10n/street_abbrev.lua
+++ b/lua_osml10/osml10n/street_abbrev.lua
@@ -107,8 +107,17 @@ abbrev_func_all.en = function(longname)
      abbrev = a
      break
     end
-  end 
+  end
 
+  for _,obj in ipairs({
+  {'%f[%a]Doctor%f[%A]', 'Dr.'},
+  {'%f[%a]Junior%f[%A]', 'Jr.'},
+  {'%f[%a]Saint%f[%A]', 'St.'},
+  {'%f[%a]Mount%f[%A]', 'Mt.'}
+}) do
+  abbrev = string.gsub(abbrev, obj[1], obj[2])
+end
+  
   for _,obj in ipairs({
     {'North%f[%A]','N'},
     {'South%f[%A]','S'},

--- a/lua_osml10/osml10n/street_abbrev.lua
+++ b/lua_osml10/osml10n/street_abbrev.lua
@@ -93,7 +93,15 @@ abbrev_func_all.en = function(longname)
     {'Crescent%f[%A]','Cres.'},
     {'Court%f[%A]','Ct.'},
     {'Expressway%f[%A]','Expy.'},
-    {'Freeway%f[%A]','Fwy.'}}) do
+    {'Freeway%f[%A]','Fwy.'},
+    {'Trail%f[%A]', 'Trl.'},
+    {'Circle%f[%A]', 'Cir.'},
+    {'Way%f[%A]', 'Wy.'},
+    {'Terrace%f[%A]', 'Ter.'},
+    {'Highway%f[%A]', 'Hwy.'},
+    {'Passage%f[%A]', 'Pass.'},
+    {'Route%f[%A]', 'Rte.'}
+    }) do
     local a = string.gsub(abbrev,obj[1], obj[2])
     if a ~= abbrev then
      abbrev = a
@@ -106,7 +114,7 @@ abbrev_func_all.en = function(longname)
     {'South%f[%A]','S'},
     {'West%f[%A]','W'},
     {'East%f[%A]','E'},
-    {'Nortwest%f[%A]','NW'},
+    {'Northwest%f[%A]','NW'},
     {'Northeast%f[%A]','NE'},
     {'Southwest%f[%A]','SW'},
     {'Southeast%f[%A]','SE'}}) do


### PR DESCRIPTION
Hello. I have noticed that some words commonly used English words don't get abbreviated. I've included them in the English loops section. Additionally, "Northwest" is misspelled as "Nortwest," so, for example, "Northwest Parkway" only gets abbreviated to "Northwest Pkwy.", not "NW Pkwy." as expected.Pleaae implement these changes as soon as possible. Thank you.