### PR TITLE
Make user for daemon dynamic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,11 @@ install-lua:
 	chmod -R go+rX $(TARGETDIR)/share/lua/$(LUAV)/osml10n
 
 systemd-service:
-	sed -e "s;%PYTARGET%;$(PYTARGET);g" transcription-daemon/geo-transcript-srv.service.template >/etc/systemd/system/osml10n.service
+	sed -e "s;%PYTARGET%;$(PYTARGET);g" \
+        -e "s;%NOBODY%;nobody;g" \
+        -e "s;%NOGROUP%;nogroup;g" \
+        transcription-daemon/geo-transcript-srv.service.template \
+        >/etc/systemd/system/osml10n.service
 
 test:
 	cd lua_osml10/tests/ && ./runtests.lua

--- a/transcription-daemon/geo-transcript-srv.service.template
+++ b/transcription-daemon/geo-transcript-srv.service.template
@@ -6,8 +6,8 @@ TimeoutStartSec=0
 Restart=always
 Type=notify
 NotifyAccess=all
-User=nobody
-Group=nogroup
+User=%NOBODY%
+Group=%NOGROUP%
 
 ExecStart=%PYTARGET%/bin/geo-transcript-srv.py -s
 # Max number of open files


### PR DESCRIPTION
If your virtual environment is in a different folder than in 
https://github.com/giggls/osml10n/commit/eff0ed53a4ce1bcdba1f2a1ed215896d629685e6, 
you might have permission problems running the daemon.

What do you think about making the User and Group in the systemd service dynamic?