### PR TITLE
also support pythainlp instead of tltk

### DIFF
--- a/lua_osml10/tests/runtests.lua
+++ b/lua_osml10/tests/runtests.lua
@@ -157,9 +157,9 @@ checkoutput(osml10n.geo_transcript,"geo_transcript","hàn zì 100 abc",'42','漢
 checkoutput(osml10n.geo_transcript,"geo_transcript","běi jīng",'42','北京',{-30, 49, -29, 50})
 
 -- Thailand
-checkoutput(osml10n.geo_transcript,"geo_transcript","hongsamut prachachon",'42','ห้องสมุดประชาชน',{100, 14, 101, 15})
+checkoutput(osml10n.geo_transcript,"geo_transcript","hongsamutprachachon",'42','ห้องสมุดประชาชน',{100, 14, 101, 15})
 checkoutput(osml10n.geo_transcript,"geo_transcript","thai thanon khaosan 100",'42','thai ถนนข้าวสาร 100',{100, 14, 101, 15})
-checkoutput(osml10n.geo_transcript,"geo_transcript","anusawari phraya ratsa da nu pradit",'42','อนุสาวรีย์พระยารัษฎาณุประดิษฐ์',{100, 14, 101, 15})
+checkoutput(osml10n.geo_transcript,"geo_transcript","anusawari phraya ratsada nu pradit",'42','อนุสาวรีย์พระยารัษฎาณุประดิษฐ์',{100, 14, 101, 15})
 
 -- Macau
 checkoutput(osml10n.geo_transcript,"geo_transcript","hōeng góng",'42',"香港",{113.54, 22.16, 113.58, 22.2})

--- a/setup.py
+++ b/setup.py
@@ -22,16 +22,12 @@ setup(
     version=vers,
     install_requires=[
         "setuptools",
-        "scipy",
-        "scikit-learn", 
         "pykakasi == 2.3.0",
-        "pythainlp",
+        "pythainlp[thai2rom]",
         "pinyin_jyutping_sentence == 1.3",
         "pyicu",
         "shapely",
-        "sdnotify",
-        "requests",
-        "pandas"
+        "sdnotify"
     ],
     scripts = [ "transcription-daemon/geo-transcript-srv.py", "transcription-cli/transcribe.py" ],
     packages = [ "osml10n" ],

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "scipy",
         "scikit-learn", 
         "pykakasi == 2.3.0",
-        "tltk == 1.9.1",
+        "pythainlp",
         "pinyin_jyutping_sentence == 1.3",
         "pyicu",
         "shapely",
@@ -33,9 +33,6 @@ setup(
         "requests",
         "pandas"
     ],
-    extras_require={
-        "pythainlp": ["pythainlp"]
-    },
     scripts = [ "transcription-daemon/geo-transcript-srv.py", "transcription-cli/transcribe.py" ],
     packages = [ "osml10n" ],
     package_data = { 'osml10n' : [ 'boundaries/**' ] }

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,9 @@ setup(
         "requests",
         "pandas"
     ],
+    extras_require={
+        "pythainlp": ["pythainlp"]
+    },
     scripts = [ "transcription-daemon/geo-transcript-srv.py", "transcription-cli/transcribe.py" ],
     packages = [ "osml10n" ],
     package_data = { 'osml10n' : [ 'boundaries/**' ] }

--- a/transcription-daemon/geo-transcript-srv.py
+++ b/transcription-daemon/geo-transcript-srv.py
@@ -1,4 +1,4 @@
-#!/home/sve25126/tmp/foo/bin/python3
+#!/usr/bin/python3
 
 import argparse
 import asyncio
@@ -53,12 +53,34 @@ except Exception as ex:
 
 try:
   # thai language in TH
-  import tltk
-except Exception as ex:
-  sys.stderr.write("\nERROR: unable to load python module tltk! Probably the following command will work:\n")
-  sys.stderr.write("pip install tltk\n\n")
-  sys.stderr.write("Error message was:\n%s\n" % ex)
-  sys.exit(1)
+  from pythainlp.tokenize import word_tokenize
+  from pythainlp.transliterate import romanize
+  
+  try:
+    # check if the Machine Learning based engine is available, if not use strict rules
+    romanize("ห้องสมุดประชาชน", engine="thai2rom")
+    def thai_romanize(st):
+      words = word_tokenize(st, engine="newmm")
+      return " ".join([romanize(w, engine="thai2rom") for w in words]).strip()
+    thai_type = "pythainlp (thai2rom)"
+  except:
+    def thai_romanize(st):
+      words = word_tokenize(st, engine="newmm")
+      return " ".join([romanize(w, engine="royin") for w in words]).strip()
+    thai_type = "pythainlp (royin)"
+  thai_version = version("pythainlp")
+except Exception as exp:
+  try:
+    import tltk
+    def thai_romanize(st):
+      return tltk.nlp.th2roman(st).rstrip('<s/>').rstrip()
+    thai_type = "tltk"
+    thai_version = version("tltk")
+  except Exception as ex:
+    sys.stderr.write("\nERROR: unable to load python modules for thai support! Probably the following command will work:\n")
+    sys.stderr.write("pip install pythainlp, pip install tltk\n\n")
+    sys.stderr.write("Error message were:\n%s\n%s\n" % (exp, ex))
+    sys.exit(1)
 
 try:
   # Cantonese transcription
@@ -93,9 +115,9 @@ def thai_transcript(inpstr):
     if (unicodedata.name(st[0]).split(' ')[0] == 'THAI'):
       transcript=''
       try:
-        transcript=tltk.nlp.th2roman(st).rstrip('<s/>').rstrip()
+        transcript=thai_romanize(st)
       except:
-        sys.stderr.write("tltk error transcribing >%s<\n" % st)
+        sys.stderr.write("%s error transcribing >%s<\n" % (thai_type, st))
         return(None)
       latin=latin+transcript
     else:
@@ -301,7 +323,7 @@ async def main():
     await server.serve_forever()
 
 if __name__ == "__main__":
-  sys.stdout.write("ready.\n(using pykakasi "+version('pykakasi')+', '+"tltk "+version('tltk')+', '+"pinyin_jyutping_sentence "+version('pinyin_jyutping_sentence')+')\n')
+  sys.stdout.write("ready.\n(using pykakasi "+version('pykakasi')+', '+thai_type+' '+thai_version+', '+"pinyin_jyutping_sentence "+version('pinyin_jyutping_sentence')+')\n')
   if args.sdnotify:
     import sdnotify
     sdnotify.SystemdNotifier().notify("READY=1")


### PR DESCRIPTION
Support pythainlp in addition to tltk. tltk wont work anymore on newer python versions and the model data probably cannot be transferred, so it is a dead end.

This will result in differences in the transliteration, but it seems the pythainlp variant is actually better.

```
calling osml10n.geo_transcript("42", "ห้องสมุดประชาชน", { 100, 14, 101, 15 }):
[ERROR] (expected hongsamut prachachon, got hongsamutprachachon)
calling osml10n.geo_transcript("42", "thai ถนนข้าวสาร 100", { 100, 14, 101, 15 }):
[OK] (expected thai thanon khaosan 100, got thai thanon khaosan 100)
calling osml10n.geo_transcript("42", "อนุสาวรีย์พระยารัษฎาณุประดิษฐ์", { 100, 14, 101, 15 }):
[ERROR] (expected anusawari phraya ratsa da nu pradit, got anusawari phraya ratsada nu pradit)

```
Anyway the change supports both.