### PR TITLE
Add missing french abbreviation and testcases

### DIFF
--- a/lua_osml10/osml10n/street_abbrev.lua
+++ b/lua_osml10/osml10n/street_abbrev.lua
@@ -138,6 +138,7 @@ end
 end
 
 -- replaces some common parts of French street names with their abbreviation
+-- * See rules of the french post: https://www.laposte.fr/envoyer/abreviation-adresses-postales
 abbrev_func_all.fr = function(longname)
   local abbrev = longname
   -- These are also French names and Avenue is not at the beginning of the Name
@@ -154,6 +155,7 @@ abbrev_func_all.fr = function(longname)
     {'^Boulevard%f[%A]','Bd'},
     {'^Chemin%f[%A]','Ch.'},
     {'^Esplanade%f[%A]','Espl.'},
+    {'^Faubourg%f[%A]','Faub.'},
     {'^Impasse%f[%A]','Imp.'},
     {'^Passage%f[%A]','Pass.'},
     {'^Promenade%f[%A]','Prom.'},

--- a/lua_osml10/tests/de_tests.csv
+++ b/lua_osml10/tests/de_tests.csv
@@ -1,4 +1,7 @@
 Doktor-No-Straße,Dr.-No-Str.
 Schillerstraße,Schillerstr.
+Einsteinstrasse,Einsteinstr.
 Kronenplatz,Kronenpl.
 Gottesauer Platz,Gottesauer Pl.
+Mühleplatz,Mühlepl.
+Obere Hauptgasse,Obere Hauptg.

--- a/lua_osml10/tests/fr_tests.csv
+++ b/lua_osml10/tests/fr_tests.csv
@@ -6,6 +6,7 @@ Avenue de la Gare,Av. de la Gare
 Boulevard de Pérolles,Bd de Pérolles
 Chemin des bains,Ch. des bains
 Esplanade de lancienne gare,Espl. de lancienne gare
+Faubourg du Lac,Faub. du Lac
 Impasse de la forêt,Imp. de la forêt
 Passage de Cardinal,Pass. de Cardinal
 Promenade du Barrage,Prom. du Barrage


### PR DESCRIPTION
- Added abbreviation for 'Faubourg' in French street names.
- Added link to french postal service source
- Add test cases (fr / de)